### PR TITLE
Barra de vida y rediseño de todos los paneles

### DIFF
--- a/src/view/Gui/Panel1.java
+++ b/src/view/Gui/Panel1.java
@@ -2,8 +2,24 @@ package src.view.Gui;
 
 import src.controller.Controller;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Image;
+
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 
 public class Panel1 extends JPanel {
@@ -18,11 +34,19 @@ public class Panel1 extends JPanel {
 
         setLayout(new BorderLayout());
 
+        // Fondo degradado
+        setOpaque(false);
+
         // Paneles
-        JPanel centerPanel = new JPanel(new GridLayout(1, 2, 20, 0));
+        JPanel centerPanel = new JPanel(new GridLayout(1, 2, 40, 0));
+        centerPanel.setOpaque(false);
+
         JPanel leftPanel = new JPanel(new BorderLayout());
+        leftPanel.setOpaque(false);
         JPanel rightPanel = new JPanel(new BorderLayout());
+        rightPanel.setOpaque(false);
         JPanel buttonPanel = new JPanel();
+        buttonPanel.setOpaque(false);
 
         // Imágenes
         ImageIcon titleImage = new ImageIcon(new ImageIcon("src/images/battleTitle.png").getImage().getScaledInstance(350, 200, Image.SCALE_SMOOTH));
@@ -39,21 +63,41 @@ public class Panel1 extends JPanel {
         trainer1Image.setHorizontalAlignment(SwingConstants.CENTER);
         trainer2Image.setHorizontalAlignment(SwingConstants.CENTER);
 
+
+
         // Etiqueta del color de cada entrenador
         JLabel trainerLabel1 = new JLabel("Entrenador Azul:");
         JLabel trainerLabel2 = new JLabel("Entrenador Rojo:");
 
-        // Posición de los labels texto de cada entrenador
+        // Posición y estilo de los labels texto de cada entrenador
         trainerLabel1.setHorizontalAlignment(SwingConstants.CENTER);
         trainerLabel2.setHorizontalAlignment(SwingConstants.CENTER);
+        trainerLabel1.setFont(new Font("Arial", Font.BOLD, 16));
+        trainerLabel2.setFont(new Font("Arial", Font.BOLD, 16));
+        trainerLabel1.setForeground(new Color(0x1976D2));
+        trainerLabel2.setForeground(new Color(0xD32F2F));
 
-        // Campos de textos
-        trainerName1 = new JTextField(5);
-        trainerName2 = new JTextField(5);
+        // Campos de textos personalizados
+        trainerName1 = new JTextField(8);
+        trainerName2 = new JTextField(8);
+        trainerName1.setFont(new Font("Arial", Font.BOLD, 16));
+        trainerName1.setBackground(new Color(0xE3F2FD));
+        trainerName1.setBorder(BorderFactory.createLineBorder(new Color(0x1976D2), 2, true));
+        trainerName2.setFont(new Font("Arial", Font.BOLD, 16));
+        trainerName2.setBackground(new Color(0xFFEBEE));
+        trainerName2.setBorder(BorderFactory.createLineBorder(new Color(0xD32F2F), 2, true));
 
-        // Botones de inicio y carga
+        // Botones de inicio y carga personalizados
         startButton = new JButton("Nueva Partida");
         loadButton = new JButton("Cargar partida");
+        startButton.setBackground(new Color(0x1976D2));
+        startButton.setForeground(Color.WHITE);
+        startButton.setFont(new Font("Arial", Font.BOLD, 14));
+        startButton.setFocusPainted(false);
+        loadButton.setBackground(new Color(0xD32F2F));
+        loadButton.setForeground(Color.WHITE);
+        loadButton.setFont(new Font("Arial", Font.BOLD, 14));
+        loadButton.setFocusPainted(false);
 
         // Añadir los elementos a los paneles correspondientes
         leftPanel.add(trainer1Image, BorderLayout.NORTH);
@@ -77,6 +121,16 @@ public class Panel1 extends JPanel {
 
         startButton.addActionListener(e -> checkTextFields());
         loadButton.addActionListener(e -> uploadGame());
+    }
+
+    // Fondo degradado
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        GradientPaint gp = new GradientPaint(0, 0, new Color(0xB2DFDB), 0, getHeight(), new Color(0xE1BEE7));
+        g2d.setPaint(gp);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
     }
 
     // Comprobación de los campos llenos

--- a/src/view/Gui/Panel2.java
+++ b/src/view/Gui/Panel2.java
@@ -2,10 +2,29 @@ package src.view.Gui;
 
 import src.controller.Controller;
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Image;
 import java.util.Enumeration;
 import java.util.Queue;
-import javax.swing.*;
+
+import javax.swing.AbstractButton;
+import javax.swing.BorderFactory;
+import javax.swing.ButtonGroup;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
 
 public class Panel2 extends JPanel {
 
@@ -17,19 +36,27 @@ public class Panel2 extends JPanel {
     private JRadioButton radioButton1Red, radioButton2Red, radioButton3Red;
     private ButtonGroup leftButtonGroup, rightButtonGroup;
 
-
     public Panel2() {
 
         setLayout(new BorderLayout());
+        setOpaque(false);
 
         //Paneles
         JPanel centerPanel = new JPanel(new GridLayout(1, 2, 20, 0));
-        JPanel buttonPanel = new JPanel();
-        JPanel leftPanel = new JPanel(new BorderLayout());
-        JPanel leftRadioPanel = new JPanel(new GridLayout(3, 1, 10, 10));
-        JPanel rightPanel = new JPanel(new BorderLayout());
-        JPanel rightRadioPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+        centerPanel.setOpaque(false);
 
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setOpaque(false);
+
+        JPanel leftPanel = new JPanel(new BorderLayout());
+        leftPanel.setOpaque(false);
+        JPanel leftRadioPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+        leftRadioPanel.setOpaque(false);
+
+        JPanel rightPanel = new JPanel(new BorderLayout());
+        rightPanel.setOpaque(false);
+        JPanel rightRadioPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+        rightRadioPanel.setOpaque(false);
 
         //Imagenes
         ImageIcon blueTrainerImageIcon = new ImageIcon(new ImageIcon("src/images/blueTrainer.png").getImage().getScaledInstance(150, 150, Image.SCALE_SMOOTH));
@@ -37,20 +64,24 @@ public class Panel2 extends JPanel {
 
         //Etiquetas Izquierdas
         blueTrainerLabel = new JLabel("", SwingConstants.CENTER);
-        blueTrainerLabel.setFont(new Font("Arial", Font.BOLD, 16));
+        blueTrainerLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        blueTrainerLabel.setForeground(new Color(0x1976D2));
         JLabel blueTrainerImageLabel = new JLabel(blueTrainerImageIcon);
         blueTrainerImageLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
 
         //Etiquetas Derechas
-        redTrainerLabel = new JLabel("", SwingConstants.CENTER); // Nombre del entrenador 2
-        redTrainerLabel.setFont(new Font("Arial", Font.BOLD, 16));
+        redTrainerLabel = new JLabel("", SwingConstants.CENTER);
+        redTrainerLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        redTrainerLabel.setForeground(new Color(0xD32F2F));
         JLabel redTrainerImageLabel = new JLabel(redTrainerImageIcon);
         redTrainerImageLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
 
         //Botones de tipo Radio
-            //Izquierda
+        Font radioFont = new Font("Arial", Font.BOLD, 15);
+
+        //Izquierda
         radioButton1Blue = new JRadioButton();
         radioButton2Blue = new JRadioButton();
         radioButton3Blue = new JRadioButton();
@@ -59,7 +90,15 @@ public class Panel2 extends JPanel {
         radioButton2Blue.setActionCommand("Button2Left");
         radioButton3Blue.setActionCommand("Button3Left");
 
-            //Derecha
+        radioButton1Blue.setFont(radioFont);
+        radioButton2Blue.setFont(radioFont);
+        radioButton3Blue.setFont(radioFont);
+
+        radioButton1Blue.setBackground(new Color(0xE3F2FD));
+        radioButton2Blue.setBackground(new Color(0xE3F2FD));
+        radioButton3Blue.setBackground(new Color(0xE3F2FD));
+
+        //Derecha
         radioButton1Red = new JRadioButton();
         radioButton2Red = new JRadioButton();
         radioButton3Red = new JRadioButton();
@@ -68,9 +107,15 @@ public class Panel2 extends JPanel {
         radioButton2Red.setActionCommand("Button2Right");
         radioButton3Red.setActionCommand("Button3Right");
 
+        radioButton1Red.setFont(radioFont);
+        radioButton2Red.setFont(radioFont);
+        radioButton3Red.setFont(radioFont);
+
+        radioButton1Red.setBackground(new Color(0xFFEBEE));
+        radioButton2Red.setBackground(new Color(0xFFEBEE));
+        radioButton3Red.setBackground(new Color(0xFFEBEE));
 
         //Grupos de botones
-
         leftButtonGroup = new ButtonGroup();
         leftButtonGroup.add(radioButton1Blue);
         leftButtonGroup.add(radioButton2Blue);
@@ -81,16 +126,33 @@ public class Panel2 extends JPanel {
         rightButtonGroup.add(radioButton2Red);
         rightButtonGroup.add(radioButton3Red);
 
+        // Bordes y separación
+        leftPanel.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(0x1976D2), 2, true),
+            BorderFactory.createEmptyBorder(10, 10, 10, 10)
+        ));
+        rightPanel.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(0xD32F2F), 2, true),
+            BorderFactory.createEmptyBorder(10, 10, 10, 10)
+        ));
 
         // Botón "Empezar Batalla"
         JButton startBattleButton = new JButton("Empezar Batalla");
+        startBattleButton.setBackground(new Color(0x1976D2));
+        startBattleButton.setForeground(Color.WHITE);
+        startBattleButton.setFont(new Font("Arial", Font.BOLD, 14));
+        startBattleButton.setFocusPainted(false);
+
         // Botón "Guardar Partida"
         JButton saveGame = new JButton("Guardar Partida");
+        saveGame.setBackground(new Color(0xD32F2F));
+        saveGame.setForeground(Color.WHITE);
+        saveGame.setFont(new Font("Arial", Font.BOLD, 14));
+        saveGame.setFocusPainted(false);
 
         // Acción del botón
         startBattleButton.addActionListener(e -> start());
         saveGame.addActionListener(e -> saveGame());
-        // Añadir elementos en los paneles respectivos
 
         //Izquierdos
         leftPanel.add(blueTrainerLabel, BorderLayout.NORTH);
@@ -111,15 +173,25 @@ public class Panel2 extends JPanel {
         rightPanel.add(rightRadioPanel, BorderLayout.SOUTH);
 
         // Añadir boton al panel de boton
-
+        buttonPanel.setBorder(new EmptyBorder(10, 0, 10, 0));
         buttonPanel.add(startBattleButton);
         buttonPanel.add(saveGame);
-        // Añadir paneles izquierdo y derecho al centro y agregar
 
+        // Añadir paneles izquierdo y derecho al centro y agregar
         centerPanel.add(leftPanel);
         centerPanel.add(rightPanel);
         add(centerPanel, BorderLayout.CENTER);
         add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    // Fondo degradado
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        GradientPaint gp = new GradientPaint(0, 0, new Color(0xB2DFDB), 0, getHeight(), new Color(0xE1BEE7));
+        g2d.setPaint(gp);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
     }
 
     public void setNamesPokemons(Queue<String> namesBlue, Queue<String> namesRed){
@@ -134,23 +206,22 @@ public class Panel2 extends JPanel {
 
     public void updateAlivePokemons(Queue<Boolean> aliveBlue, Queue<Boolean> aliveRed) {
 
-            //limpiar seleccion de los pokemones del entrenador azul
-            leftButtonGroup.clearSelection();
+        //limpiar seleccion de los pokemones del entrenador azul
+        leftButtonGroup.clearSelection();
 
-            // Desactivar botones del entrenador azul si el Pokémon no está vivo
-            radioButton1Blue.setEnabled(aliveBlue.poll());
-            radioButton2Blue.setEnabled(aliveBlue.poll());
-            radioButton3Blue.setEnabled(aliveBlue.poll());
+        // Desactivar botones del entrenador azul si el Pokémon no está vivo
+        radioButton1Blue.setEnabled(aliveBlue.poll());
+        radioButton2Blue.setEnabled(aliveBlue.poll());
+        radioButton3Blue.setEnabled(aliveBlue.poll());
 
-            //limpiar seleccion de los pokemones del entrenador rojo
-            rightButtonGroup.clearSelection();
+        //limpiar seleccion de los pokemones del entrenador rojo
+        rightButtonGroup.clearSelection();
 
-            // Desactivar botones del entrenador rojo si el Pokémon no está vivo
-            radioButton1Red.setEnabled(aliveRed.poll());
-            radioButton2Red.setEnabled(aliveRed.poll());
-            radioButton3Red.setEnabled(aliveRed.poll());
-        }
-
+        // Desactivar botones del entrenador rojo si el Pokémon no está vivo
+        radioButton1Red.setEnabled(aliveRed.poll());
+        radioButton2Red.setEnabled(aliveRed.poll());
+        radioButton3Red.setEnabled(aliveRed.poll());
+    }
 
     private void start(){
         String pokemonBlue = "";
@@ -159,7 +230,7 @@ public class Panel2 extends JPanel {
         for (Enumeration<AbstractButton> e = leftButtonGroup.getElements(); e.hasMoreElements();){
             AbstractButton button = e.nextElement();
             if (button.isSelected()){
-              pokemonBlue = button.getText();
+                pokemonBlue = button.getText();
             }
         }
 
@@ -195,8 +266,6 @@ public class Panel2 extends JPanel {
             }
         }
     }
-
-
 
     // Setters y Getters
     public void setTrainerBlueName(String name) {

--- a/src/view/Gui/Panel3.java
+++ b/src/view/Gui/Panel3.java
@@ -2,11 +2,86 @@ package src.view.Gui;
 
 import src.controller.Controller;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Queue;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.Timer;
+
+class BarHpPokemonPanel extends JPanel {
+    private int currHp, maxHp;
+    private final int width = 150;
+    private final int height = 20;
+
+    public BarHpPokemonPanel(int currHp, int maxHp) {
+        this.currHp = currHp;
+        this.maxHp = maxHp;
+        setPreferredSize(new Dimension(width, height + 15));
+        setOpaque(false);
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+
+        // Fondo barra
+        g.setColor(Color.BLACK);
+        g.fillRect(0, 0, width, height);
+
+        // Color según porcentaje de vida
+        Color currColor;
+        double percent = (double) currHp / maxHp;
+        if (percent >= 0.8) {
+            currColor = Color.GREEN;
+        } else if (percent >= 0.5) {
+            currColor = Color.YELLOW;
+        } else {
+            currColor = Color.RED;
+        }
+
+        int lifeWidth = (int) ((width * currHp) / (double) maxHp);
+        g.setColor(currColor);
+        g.fillRect(0, 0, lifeWidth, height);
+
+    }
+
+    public void updateHp(int newHp) {
+        Timer t = new Timer(10, e -> {
+            if (currHp == newHp) {
+                ((Timer) e.getSource()).stop();
+                return;
+            }
+            if (currHp < newHp) currHp++;
+            else currHp--;
+            repaint();
+        });
+        t.start();
+    }
+
+    public void setMaxHp(int maxHp) {
+        this.maxHp = maxHp;
+        repaint();
+    }
+}
 
 public class Panel3 extends JPanel implements ActionListener {
 
@@ -18,55 +93,83 @@ public class Panel3 extends JPanel implements ActionListener {
     private boolean isBlueTurn;
     private JLabel redPokemonHpLabel, bluePokemonHpLabel, bluePokemonImage, redPokemonImage;
     private short hpBlueInitial, hpRedInitial;
-
+    private BarHpPokemonPanel blueHpBar, redHpBar;
 
     public Panel3() {
 
         setLayout(new BorderLayout());
-        setBackground(new Color(0x8FB5DE));
+
+        // Fondo degradado
+        setOpaque(false);
 
         //Paneles
         JPanel centerPanel = new JPanel(new GridLayout(1, 2, 20, 0));
+        centerPanel.setOpaque(false);
 
         JPanel leftPanel = new JPanel(new BorderLayout());
+        leftPanel.setOpaque(false);
         JPanel leftLabelsPanel = new JPanel(new GridLayout(2, 1));
-        JPanel blueImageAndHpPanel = new JPanel(new BorderLayout());
+        leftLabelsPanel.setOpaque(false);
         JPanel blueButtonsPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+        blueButtonsPanel.setOpaque(false);
 
         JPanel rightPanel = new JPanel(new BorderLayout());
+        rightPanel.setOpaque(false);
         JPanel rightLabelsPanel = new JPanel(new GridLayout(2, 1));
-        JPanel redImageAndHpPanel = new JPanel(new BorderLayout());
+        rightLabelsPanel.setOpaque(false);
         JPanel redButtonsPanel = new JPanel(new GridLayout(3, 1, 10, 10));
+        redButtonsPanel.setOpaque(false);
 
+        // Bordes y separación
+        leftPanel.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(0x1976D2), 2, true),
+            BorderFactory.createEmptyBorder(10, 10, 10, 10)
+        ));
+        rightPanel.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(0xD32F2F), 2, true),
+            BorderFactory.createEmptyBorder(10, 10, 10, 10)
+        ));
 
         // Etiquetas
         blueTrainerLabel = new JLabel("", SwingConstants.CENTER);
-        blueTrainerLabel.setFont(new Font("Arial", Font.BOLD, 16));
+        blueTrainerLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        blueTrainerLabel.setForeground(new Color(0x1976D2));
 
         bluePokemonLabel = new JLabel("", SwingConstants.CENTER);
-        bluePokemonLabel.setFont(new Font("Arial", Font.PLAIN, 14));
+        bluePokemonLabel.setFont(new Font("Arial", Font.BOLD, 20));
+        bluePokemonLabel.setForeground(new Color(0x1976D2));
+        bluePokemonLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         bluePokemonHpLabel = new JLabel("HP = " + 0, SwingConstants.CENTER);
-        bluePokemonHpLabel.setFont(new Font("Arial", Font.PLAIN, 14));
+        bluePokemonHpLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        bluePokemonHpLabel.setForeground(new Color(0x1976D2));
+        bluePokemonHpLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         redTrainerLabel = new JLabel("", SwingConstants.CENTER);
-        redTrainerLabel.setFont(new Font("Arial", Font.BOLD, 16));
+        redTrainerLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        redTrainerLabel.setForeground(new Color(0xD32F2F));
 
         redPokemonLabel = new JLabel("", SwingConstants.CENTER);
-        redPokemonLabel.setFont(new Font("Arial", Font.PLAIN, 14));
+        redPokemonLabel.setFont(new Font("Arial", Font.BOLD, 20));
+        redPokemonLabel.setForeground(new Color(0xD32F2F));
+        redPokemonLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         redPokemonHpLabel = new JLabel("HP = " + 0, SwingConstants.CENTER);
-        redPokemonHpLabel.setFont(new Font("Arial", Font.PLAIN, 14));
+        redPokemonHpLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        redPokemonHpLabel.setForeground(new Color(0xD32F2F));
+        redPokemonHpLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         //Etiquetas de imagenes de Pokemones por defecto
-
         bluePokemonImage = new JLabel(new ImageIcon(new ImageIcon("src/images/pokemonsImages/imagenPokemonDesconocido").getImage().getScaledInstance(150, 150, Image.SCALE_SMOOTH)));
         redPokemonImage = new JLabel(new ImageIcon(new ImageIcon("src/images/pokemonsImages/imagenPokemonDesconocido").getImage().getScaledInstance(150, 150, Image.SCALE_SMOOTH)));
         bluePokemonImage.setHorizontalAlignment(SwingConstants.CENTER);
         redPokemonImage.setHorizontalAlignment(SwingConstants.CENTER);
 
-        //Botones
+        //Barra de HP
+        blueHpBar = new BarHpPokemonPanel(0, 100);
+        redHpBar = new BarHpPokemonPanel(0, 100);
 
+        //Botones
         attack1Blue = new JButton("Ataque 1");
         attack2Blue = new JButton("Ataque 2");
         attack3Blue = new JButton("Ataque 3");
@@ -75,37 +178,97 @@ public class Panel3 extends JPanel implements ActionListener {
         attack2Red = new JButton("Ataque 2");
         attack3Red = new JButton("Ataque 3");
 
+        // Personaliza botones
+        Font buttonFont = new Font("Arial", Font.BOLD, 14);
+        Color blueButtonColor = new Color(0xE3F2FD);
+        Color redButtonColor = new Color(0xFFEBEE);
 
-        //Añadir elementos a los paneles correspondientes
-            //Izquierdo
-            leftLabelsPanel.add(blueTrainerLabel);
-            leftLabelsPanel.add(bluePokemonLabel);
+        attack1Blue.setBackground(blueButtonColor);
+        attack2Blue.setBackground(blueButtonColor);
+        attack3Blue.setBackground(blueButtonColor);
+        attack1Blue.setFont(buttonFont);
+        attack2Blue.setFont(buttonFont);
+        attack3Blue.setFont(buttonFont);
 
-            blueImageAndHpPanel.add(bluePokemonImage, BorderLayout.CENTER);
-            blueImageAndHpPanel.add(bluePokemonHpLabel, BorderLayout.SOUTH);
+        attack1Red.setBackground(redButtonColor);
+        attack2Red.setBackground(redButtonColor);
+        attack3Red.setBackground(redButtonColor);
+        attack1Red.setFont(buttonFont);
+        attack2Red.setFont(buttonFont);
+        attack3Red.setFont(buttonFont);
 
-            blueButtonsPanel.add(attack1Blue);
-            blueButtonsPanel.add(attack2Blue);
-            blueButtonsPanel.add(attack3Blue);
+        // Panel izquierdo (Pokémon azul)
+        JPanel bluePokemonPanel = new JPanel();
+        bluePokemonPanel.setOpaque(false);
+        bluePokemonPanel.setLayout(new BoxLayout(bluePokemonPanel, BoxLayout.Y_AXIS));
+        bluePokemonPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-            leftPanel.add(leftLabelsPanel, BorderLayout.NORTH);
-            leftPanel.add(blueImageAndHpPanel, BorderLayout.CENTER);
-            leftPanel.add(blueButtonsPanel, BorderLayout.SOUTH);
+        bluePokemonLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        bluePokemonImage.setAlignmentX(Component.CENTER_ALIGNMENT);
+        bluePokemonHpLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        blueHpBar.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-            //Derecho
-            rightLabelsPanel.add(redTrainerLabel);
-            rightLabelsPanel.add(redPokemonLabel);
+        bluePokemonPanel.add(Box.createVerticalStrut(10));
+        bluePokemonPanel.add(bluePokemonLabel);
+        bluePokemonPanel.add(Box.createVerticalStrut(10));
+        bluePokemonPanel.add(bluePokemonImage);
+        bluePokemonPanel.add(Box.createVerticalStrut(10));
+        bluePokemonPanel.add(bluePokemonHpLabel); // HP debajo del Pokémon
+        bluePokemonPanel.add(Box.createVerticalStrut(5));
 
-            redImageAndHpPanel.add(redPokemonImage, BorderLayout.CENTER);
-            redImageAndHpPanel.add(redPokemonHpLabel, BorderLayout.SOUTH);
+        // Panel para centrar la barra de vida azul
+        JPanel blueHpBarWrapper = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+        blueHpBarWrapper.setOpaque(false);
+        blueHpBarWrapper.add(blueHpBar);
 
-            redButtonsPanel.add(attack1Red);
-            redButtonsPanel.add(attack2Red);
-            redButtonsPanel.add(attack3Red);
+        bluePokemonPanel.add(blueHpBarWrapper);
+        bluePokemonPanel.add(Box.createVerticalStrut(10));
 
-            rightPanel.add(rightLabelsPanel, BorderLayout.NORTH);
-            rightPanel.add(redImageAndHpPanel, BorderLayout.CENTER);
-            rightPanel.add(redButtonsPanel, BorderLayout.SOUTH);
+        // Panel derecho (Pokémon rojo)
+        JPanel redPokemonPanel = new JPanel();
+        redPokemonPanel.setOpaque(false);
+        redPokemonPanel.setLayout(new BoxLayout(redPokemonPanel, BoxLayout.Y_AXIS));
+        redPokemonPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        redPokemonLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        redPokemonImage.setAlignmentX(Component.CENTER_ALIGNMENT);
+        redPokemonHpLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        redHpBar.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        redPokemonPanel.add(Box.createVerticalStrut(10));
+        redPokemonPanel.add(redPokemonLabel);
+        redPokemonPanel.add(Box.createVerticalStrut(10));
+        redPokemonPanel.add(redPokemonImage);
+        redPokemonPanel.add(Box.createVerticalStrut(10));
+        redPokemonPanel.add(redPokemonHpLabel); // HP debajo del Pokémon
+        redPokemonPanel.add(Box.createVerticalStrut(5));
+
+        // Panel para centrar la barra de vida roja
+        JPanel redHpBarWrapper = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+        redHpBarWrapper.setOpaque(false);
+        redHpBarWrapper.add(redHpBar);
+
+        redPokemonPanel.add(redHpBarWrapper);
+        redPokemonPanel.add(Box.createVerticalStrut(10));
+
+        // Añadir elementos a los paneles correspondientes
+        leftLabelsPanel.add(blueTrainerLabel);
+        leftLabelsPanel.add(Box.createVerticalStrut(10));
+        leftPanel.add(leftLabelsPanel, BorderLayout.NORTH);
+        leftPanel.add(bluePokemonPanel, BorderLayout.CENTER);
+        blueButtonsPanel.add(attack1Blue);
+        blueButtonsPanel.add(attack2Blue);
+        blueButtonsPanel.add(attack3Blue);
+        leftPanel.add(blueButtonsPanel, BorderLayout.SOUTH);
+
+        rightLabelsPanel.add(redTrainerLabel);
+        rightLabelsPanel.add(Box.createVerticalStrut(10));
+        rightPanel.add(rightLabelsPanel, BorderLayout.NORTH);
+        rightPanel.add(redPokemonPanel, BorderLayout.CENTER);
+        redButtonsPanel.add(attack1Red);
+        redButtonsPanel.add(attack2Red);
+        redButtonsPanel.add(attack3Red);
+        rightPanel.add(redButtonsPanel, BorderLayout.SOUTH);
 
         //Panel Principal
         centerPanel.add(leftPanel);
@@ -124,51 +287,18 @@ public class Panel3 extends JPanel implements ActionListener {
         attack3Red.addActionListener(this);
     }
 
-    // Habilita o deshabilita los botones según el turno
-
-
-    // Maneja los clics en botones de ataque
+    // Fondo degradado
     @Override
-    public void actionPerformed(ActionEvent e) {
-        if (isBlueTurn) {
-            byte indexAttack = -1;
-            if (e.getSource().equals(attack1Blue)) {
-                indexAttack = 0;
-            } else if (e.getSource().equals(attack2Blue)) {
-                indexAttack = 1;
-            } else if (e.getSource().equals(attack3Blue)) {
-                indexAttack = 2;
-            }
-            controller.blueMakeDamage(indexAttack);
-        } else {
-            byte indexAttack = -1;
-            if (e.getSource().equals(attack1Red)) {
-                indexAttack = 0;
-            } else if (e.getSource().equals(attack2Red)) {
-                indexAttack = 1;
-            } else if (e.getSource().equals(attack3Red)) {
-                indexAttack = 2;
-            }
-            controller.redMakeDamage(indexAttack);
-        }
-
-        // Verificar si alguno de los Pokemon fue derrotado
-        controller.winner();
-        controller.checkAlivePokemon();
-
-        isBlueTurn = controller.nextTurn();
-        updateButtonStates();
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g;
+        GradientPaint gp = new GradientPaint(0, 0, new Color(0xB2DFDB), 0, getHeight(), new Color(0xE1BEE7));
+        g2d.setPaint(gp);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
     }
 
-
-    //Metodo para actualizar indices y determinar quien empieza
-    public void setPokemonIndexes(boolean turn) {
-        isBlueTurn = turn;
-        updateButtonStates();
-    }
-
+    // Habilita o deshabilita los botones según el turno
     private void updateButtonStates() {
-
         attack1Blue.setEnabled(isBlueTurn);
         attack2Blue.setEnabled(isBlueTurn);
         attack3Blue.setEnabled(isBlueTurn);
@@ -179,7 +309,6 @@ public class Panel3 extends JPanel implements ActionListener {
     }
 
     public void setNamesAttacks(Queue<String> blueAttacks, Queue<String> redAttacks) {
-
         attack1Blue.setText(blueAttacks.poll());
         attack2Blue.setText(blueAttacks.poll());
         attack3Blue.setText(blueAttacks.poll());
@@ -193,6 +322,10 @@ public class Panel3 extends JPanel implements ActionListener {
     public void updateHpLabels(short hpBlue, short hpRed, short hpInitialBlue, short hpInitialRed) {
         bluePokemonHpLabel.setText("HP = " + hpBlue  + "/" + hpInitialBlue);
         redPokemonHpLabel.setText("HP = " + hpRed + "/" + hpInitialRed);
+        blueHpBar.setMaxHp(hpInitialBlue);
+        redHpBar.setMaxHp(hpInitialRed);
+        blueHpBar.updateHp(hpBlue);
+        redHpBar.updateHp(hpRed);
     }
 
     // Setters para actualizar nombres e imágenes
@@ -228,5 +361,43 @@ public class Panel3 extends JPanel implements ActionListener {
 
     public void isBlueTurn(boolean isBlueTurn) {
         this.isBlueTurn = isBlueTurn;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (isBlueTurn) {
+            byte indexAttack = -1;
+            if (e.getSource().equals(attack1Blue)) {
+                indexAttack = 0;
+            } else if (e.getSource().equals(attack2Blue)) {
+                indexAttack = 1;
+            } else if (e.getSource().equals(attack3Blue)) {
+                indexAttack = 2;
+            }
+            controller.blueMakeDamage(indexAttack);
+        } else {
+            byte indexAttack = -1;
+            if (e.getSource().equals(attack1Red)) {
+                indexAttack = 0;
+            } else if (e.getSource().equals(attack2Red)) {
+                indexAttack = 1;
+            } else if (e.getSource().equals(attack3Red)) {
+                indexAttack = 2;
+            }
+            controller.redMakeDamage(indexAttack);
+        }
+
+        // Verificar si alguno de los Pokemon fue derrotado
+        controller.winner();
+        controller.checkAlivePokemon();
+
+        isBlueTurn = controller.nextTurn();
+        updateButtonStates();
+    }
+
+    //Metodo para actualizar indices y determinar quien empieza
+    public void setPokemonIndexes(boolean turn) {
+        isBlueTurn = turn;
+        updateButtonStates();
     }
 }


### PR DESCRIPTION
### **Mejoras visuales en todos los paneles**

- Se aplicó un fondo degradado suave en todos los paneles principales

- Se personalizaron fuentes, colores y tamaños en los labels de entrenadores, nombres de Pokémon y HP

- Se mejoró el diseño de los botones y campos de texto

- Se centraron y alinearon los elementos importantes (imágenes, nombres, HP, barras de vida).

### **Panel de selección de entrenadores (Panel1)**

- Se personalizaron los campos de texto y botones.

- Se mejoró la disposición y el espaciado de los elementos.

### **Panel de selección de Pokémon (Panel2)**

- Se mejoró el diseño de los radio buttons y se les dio color de fondo.

- Se agregaron bordes suaves y separación entre los paneles de cada entrenador.

- Se personalizaron los botones de acción.

- Se centraron y agrandaron los nombres de los entrenadores.

### **Panel de batalla (Panel3)**

- Se creó la barra de vida de los pokemones de cada entrandor

- Se reorganizó la estructura para que el nombre del Pokémon, imagen, HP y barra de vida estén apilados y centrados.

- Se mejoró la fuente y el color del nombre del Pokémon para que combine con el resto del panel.

- Se centró la barra de vida debajo del HP usando un panel con [FlowLayout]

- Se personalizaron los botones de ataque y se mejoró el espaciado.

- Se eliminaron las importaciones con *
